### PR TITLE
Fixed duplicating notifications after linkpay callback

### DIFF
--- a/app/services/notify.rb
+++ b/app/services/notify.rb
@@ -6,6 +6,9 @@ class Notify < Base
     return notify(title: 'Invoice not found',
                   error_message: "Invoice with #{parsed_response[:order_reference]} number not found") if invoice.nil?
 
+
+    return if invoice.paid?
+
     update_invoice_state(parsed_response: parsed_response, invoice: invoice)
     url = get_update_payment_url[invoice.initiator.to_sym]
     parsed_response[:invoice_number_collection] = invoice_numbers_from_multi_payment(invoice)


### PR DESCRIPTION
- Linkpay sends callbacks after every payment attempt, even if customer abandonded payment procedure. Before sending notify call to registry there was missing check if invoice was already paid. If invoice already paid no need to notify registry again and create duplicated transactions.