### PR TITLE
add endpoint for handle deposit change status

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require: rubocop-rails
 AllCops:
   Exclude:
     - 'test/**/*'
+    - 'spec/**/*'
     - 'db/**/*'
     - 'config/**/*'
     - 'bin/*'

--- a/app/controllers/api/v1/invoice_generator/deposit_status_controller.rb
+++ b/app/controllers/api/v1/invoice_generator/deposit_status_controller.rb
@@ -1,0 +1,59 @@
+module Api
+  module V1
+    module InvoiceGenerator
+      class DepositStatusController < Api::V1::InvoiceGenerator::BaseController
+        before_action :set_invoice, only: :create
+        before_action :set_status, only: :create
+
+        api! 'Invoice deposit status updates'
+
+        param :invoice_number, String, required: true
+        param :status, String, required: true
+
+        def create
+          if @invoice.update(status: @status)
+            render json: { 'message' => 'Status updated' }, status: :ok
+          else
+            error_message = "Status for #{params[:invoice_number]} wasn't updated; Status #{@status}"
+            NotifierMailer.inform_admin('Status received error', error_message).deliver_now
+            render json: { 'error' => error_message }, status: :unprocessable_entity
+          end
+        rescue StandardError => e
+          Rails.logger.info e
+          NotifierMailer.inform_admin('Status received standard error', e).deliver_now
+        end
+
+        private
+
+        # rubocop:disable Metrics/AbcSize
+        def set_invoice
+          @invoice = ::Invoice.where("description LIKE ? AND description LIKE ?", "%#{params[:domain_name]}%", "%#{params[:user_uuid]}%").first
+          return if @invoice.present? && @invoice.affiliation == 'auction_deposit'
+
+          message = "Invoice with #{params[:domain_name]} and #{params[:user_uuid]} not found in Deposit Status Controller"
+          NotifierMailer.inform_admin("Invoice with #{params[:domain_name]} and #{params[:user_uuid]} not found", message).deliver_now
+
+          render json: { 'error' => message }, status: :unprocessable_entity and return
+        end
+
+        def set_status
+          @status = reform_status[params[:status]]
+          return if %w[paid unpaid refunded].include?(@status)
+
+          message = "Wrong invoice status #{@status} in Deposit Status Controller"
+          NotifierMailer.inform_admin("Invoice status #{@status} is wrong", message).deliver_now
+
+          render json: { 'error' => message }, status: :unprocessable_entity and return
+        end
+
+        def reform_status
+          {
+            'paid' => 'paid',
+            'prepayment' => 'unpaid',
+            'returned' => 'refunded'
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/invoice_generator/invoice_status_controller.rb
+++ b/app/controllers/api/v1/invoice_generator/invoice_status_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics
 module Api
   module V1
     module InvoiceGenerator

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
         resources :oneoff, only: [:create]
         resources :deposit_prepayment, only: [:create]
         resources :bulk_payment, only: [:create]
+        resources :deposit_status, only: [:create]
       end
 
       namespace :refund do

--- a/spec/requests/api/v1/invoice_generator/deposit_status_spec.rb
+++ b/spec/requests/api/v1/invoice_generator/deposit_status_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::InvoiceGenerator::DepositStatusController', type: :request do
+  let(:invoice) { create(:invoice) }
+
+  before(:each) do
+    allow_any_instance_of(ApplicationController).to receive(:authorized).and_return(true)
+    @user_uuid = 'df0ad0b9-8b4e-4946-9562-0a2bb877156c'
+    @domain_name = 'deping10.ee'
+    @description = "auction_deposit #{@domain_name}, user_uuid #{@user_uuid}, user_email john_doe@test.ee"
+  end
+
+  it 'should update status to paid' do
+    invoice.update(status: 'unpaid', affiliation: 'auction_deposit', description: @description)
+    invoice.reload
+
+    expect(invoice.status).to eq('unpaid')
+
+    params = {
+      user_uuid: @user_uuid,
+      domain_name: @domain_name,
+      status: 'paid'
+    }
+
+    post api_v1_invoice_generator_deposit_status_index_path, params: params
+    invoice.reload
+
+    expect(invoice.status).to eq('paid')
+  end
+
+  it 'should update status to unpaid' do
+    invoice.update(status: 'paid', affiliation: 'auction_deposit', description: @description)
+    invoice.reload
+
+    expect(invoice.status).to eq('paid')
+
+    params = {
+      user_uuid: @user_uuid,
+      domain_name: @domain_name,
+      status: 'prepayment'
+    }
+
+    post api_v1_invoice_generator_deposit_status_index_path, params: params
+    invoice.reload
+
+    expect(invoice.status).to eq('unpaid')
+  end
+
+  it 'should update status to refunded' do
+    invoice.update(status: 'unpaid', affiliation: 'auction_deposit', description: @description)
+    invoice.reload
+
+    expect(invoice.status).to eq('unpaid')
+
+    params = {
+      user_uuid: @user_uuid,
+      domain_name: @domain_name,
+      status: 'returned'
+    }
+
+    post api_v1_invoice_generator_deposit_status_index_path, params: params
+    invoice.reload
+
+    expect(invoice.status).to eq('refunded')
+  end
+
+  it 'should notify if status is invalid' do
+    invoice.update(status: 'unpaid', affiliation: 'auction_deposit', description: @description)
+    invoice.reload
+
+    expect(invoice.status).to eq('unpaid')
+
+    params = {
+      user_uuid: @user_uuid,
+      domain_name: @domain_name,
+      status: 'refunded'
+    }
+
+    post api_v1_invoice_generator_deposit_status_index_path, params: params
+    invoice.reload
+
+    expect(response.status).to eq 422
+    expect(invoice.status).to eq('unpaid')
+  end
+
+  it 'should notify if invoice not exists' do
+    invoice.update(status: 'unpaid', affiliation: 'auction_deposit', description: @description)
+    invoice.reload
+
+    expect(invoice.status).to eq('unpaid')
+
+    params = {
+      user_uuid: 'non-existing-uuid',
+      domain_name: @domain_name,
+      status: 'paid'
+    }
+
+    post api_v1_invoice_generator_deposit_status_index_path, params: params
+    invoice.reload
+
+    expect(response.status).to eq 422
+    expect(JSON.parse(response.body)['error']).to eq 'Invoice with deping10.ee and non-existing-uuid not found in Deposit Status Controller'
+    expect(invoice.status).to eq('unpaid')
+  end
+
+  it 'should notify if invoice is not auction_deposit' do
+    invoice.update(status: 'unpaid', affiliation: 'regular', description: @description)
+    invoice.reload
+
+    expect(invoice.status).to eq('unpaid')
+
+    params = {
+      user_uuid: @user_uuid,
+      domain_name: @domain_name,
+      status: 'refunded'
+    }
+
+    post api_v1_invoice_generator_deposit_status_index_path, params: params
+    invoice.reload
+
+    expect(response.status).to eq 422
+    expect(JSON.parse(response.body)['error']).to eq "Invoice with deping10.ee and df0ad0b9-8b4e-4946-9562-0a2bb877156c not found in Deposit Status Controller"
+    expect(invoice.status).to eq('unpaid')
+
+  end
+end


### PR DESCRIPTION
close #https://github.com/internetee/auction_center/issues/1130
related #https://github.com/internetee/auction_center/pull/1148

**What's this?**
This PR is related to this ticket #https://github.com/internetee/auction_center/issues/1130. The essence is that when a deposit status is updated on the auction side, the same status is not updated in the billing system. This can lead to a situation where the auction has one status and the billing system has another, making it difficult to determine which is the source of truth.

**What did you do?**
I added a new controller that receives user and auction data, searches for the required invoice through pattern matching in the invoice table description field, and updates its status. I also wrote tests to check how the status is correctly parsed and the invoice is found.

**How to check?**
You need to check how different statuses are changed in the billing system when the administrator changes the deposit status in the auction.

**How to review?**

- Make sure the code is clean.
- Make sure the tests cover all functionalities.
- Ensure that the code does not add additional complexity and does not affect the functionality of other parts of the code.