### PR TITLE
added support lhv connect for auction

### DIFF
--- a/app/controllers/api/v1/invoice_generator/reference_number_generator_controller.rb
+++ b/app/controllers/api/v1/invoice_generator/reference_number_generator_controller.rb
@@ -3,14 +3,17 @@ class Api::V1::InvoiceGenerator::ReferenceNumberGeneratorController < Applicatio
 
   def create
     initiator = params['initiator']
+    owner = params['owner']
+    email = params['email']
     reference_number = nil
+
     loop do
       reference_number = generate
 
-      reference = Reference.find_by(reference_number: reference_number)
+      reference = Reference.find_by(reference_number:)
       next unless reference.nil?
 
-      Reference.create!(reference_number: reference_number, initiator: initiator)
+      Reference.create!(reference_number:, initiator:, email:, owner:)
       break
     end
 

--- a/app/jobs/payment_lhv_connect_job.rb
+++ b/app/jobs/payment_lhv_connect_job.rb
@@ -22,7 +22,7 @@ class PaymentLhvConnectJob < ApplicationJob
     api = Lhv::ConnectApi.new
     api.cert = cert
     api.key = key
-    # api.ca_file = ENV['lhv_ca_file']
+
     api.dev_mode = ENV['lhv_dev_mode'] == 'true'
 
     incoming_transactions = []
@@ -43,11 +43,11 @@ class PaymentLhvConnectJob < ApplicationJob
 
     sorted_by_ref_number = incoming_transactions.group_by { |x| x[:payment_reference_number] }
     sorted_by_ref_number.each do |s|
-      Rails.logger.info "=========== Sending to registry ==========="
+      Rails.logger.info '=========== Sending to registry ==========='
       Rails.logger.info s[1]
-      Rails.logger.info "==========================================="
+      Rails.logger.info '==========================================='
 
-      send_transactions_to_registry(params: s[1])
+      send_transactions(params: s[1], payment_reference_number: s[0])
     end
 
     Rails.logger.info "Transactions processed: #{incoming_transactions.size}"
@@ -66,7 +66,7 @@ class PaymentLhvConnectJob < ApplicationJob
     return unless valid_ref_no?(reference)
 
     ref = Reference.find_by(reference_number: reference)
-    inform_admin(reference: reference, body: credit_transaction) and return nil if ref.nil?
+    inform_admin(reference:, body: credit_transaction) and return nil if ref.nil?
 
     reference
   end
@@ -77,12 +77,12 @@ class PaymentLhvConnectJob < ApplicationJob
   end
 
   def valid_ref_no?(match)
-    return true if Billing::ReferenceNo.valid?(match)
+    true if Billing::ReferenceNo.valid?(match)
   end
 
   def inform_admin(reference:, body:)
-    Rails.logger.info "Inform to admin that reference number not found"
-    BillingMailer.inform_admin(reference_number: reference, body: body).deliver_now
+    Rails.logger.info 'Inform to admin that reference number not found'
+    BillingMailer.inform_admin(reference_number: reference, body:).deliver_now
   end
 
   def open_ssl_keystore
@@ -92,8 +92,10 @@ class PaymentLhvConnectJob < ApplicationJob
   end
 
   # https://registry.test/eis_billing/lhv_connect_transactions
-  def send_transactions_to_registry(params:)
-    uri = URI.parse(url_transaction)
+  def send_transactions(params:, payment_reference_number:)
+    reference = Reference.find_by(reference_number: payment_reference_number)
+
+    uri = URI.parse(url[reference.initiator])
     http = Net::HTTP.new(uri.host, uri.port)
   
     if Rails.env.development? || Rails.env.test?
@@ -103,13 +105,13 @@ class PaymentLhvConnectJob < ApplicationJob
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
-  
-    res = http.post(url_transaction, params.to_json, headers)
-  
-    Rails.logger.info ">>>>>>"
+
+    res = http.post(url[reference.initiator], params.to_json, headers)
+
+    Rails.logger.info '>>>>>>'
     Rails.logger.info res.body
-    Rails.logger.info ">>>>>>"
-  end  
+    Rails.logger.info '>>>>>>'
+  end
 
   def generate_token
     JWT.encode(payload, billing_secret)
@@ -121,13 +123,24 @@ class PaymentLhvConnectJob < ApplicationJob
 
   def headers
     {
-    'Authorization' => "Bearer #{generate_token}",
-    'Content-Type' => 'application/json',
+      'Authorization' => "Bearer #{generate_token}",
+      'Content-Type' => 'application/json'
     }
   end
 
-  def url_transaction
+  def url
+    {
+      registry: registry_url_transaction,
+      auction: auction_url_transaction
+    }
+  end
+
+  def registry_url_transaction
     "#{ENV['base_registry']}/eis_billing/lhv_connect_transactions"
+  end
+
+  def auction_url_transaction
+    "#{ENV['base_auction']}/eis_billing/lhv_connect_transactions"
   end
 
   def billing_secret
@@ -139,6 +152,6 @@ class PaymentLhvConnectJob < ApplicationJob
                    currency: 'EUR',
                    date: Time.zone.today,
                    payment_reference_number: '7366488',
-                   payment_description: "description 7366488")
+                   payment_description: 'description 7366488')
   end
 end

--- a/app/jobs/payment_lhv_connect_job.rb
+++ b/app/jobs/payment_lhv_connect_job.rb
@@ -43,7 +43,7 @@ class PaymentLhvConnectJob < ApplicationJob
 
     sorted_by_ref_number = incoming_transactions.group_by { |x| x[:payment_reference_number] }
     sorted_by_ref_number.each do |s|
-      Rails.logger.info '=========== Sending to registry ==========='
+      Rails.logger.info '=========== Sending transaction ==========='
       Rails.logger.info s[1]
       Rails.logger.info '==========================================='
 
@@ -95,7 +95,7 @@ class PaymentLhvConnectJob < ApplicationJob
   def send_transactions(params:, payment_reference_number:)
     reference = Reference.find_by(reference_number: payment_reference_number)
 
-    uri = URI.parse(url[reference.initiator])
+    uri = URI.parse(url[reference.initiator.to_sym])
     http = Net::HTTP.new(uri.host, uri.port)
   
     if Rails.env.development? || Rails.env.test?
@@ -106,7 +106,7 @@ class PaymentLhvConnectJob < ApplicationJob
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
 
-    res = http.post(url[reference.initiator], params.to_json, headers)
+    res = http.post(url[reference.initiator.to_sym], params.to_json, headers)
 
     Rails.logger.info '>>>>>>'
     Rails.logger.info res.body

--- a/app/jobs/save_reference_data_job.rb
+++ b/app/jobs/save_reference_data_job.rb
@@ -4,19 +4,18 @@ class SaveReferenceDataJob < ApplicationJob
     skipped_count = 0
 
     response.each do |data|
-      reference_number = data["reference_number"]
-      initiator = data["initiator"]
-      registrar_name = data["registrar_name"]
+      reference_number = data['reference_number']
+      initiator = data['initiator']
+      registrar_name = data['registrar_name']
 
-      unless Reference.find_by(reference_number: reference_number, initiator: initiator, owner: registrar_name).nil?
+      if Reference.find_by(reference_number:, initiator:, owner: registrar_name).present?
         skipped_count += 1
 
         next
       end
 
-      log_request(reference_number: reference_number, initiator: initiator, owner: registrar_name)
-
-      Reference.create!(reference_number: reference_number, initiator: initiator, owner: registrar_name)
+      Reference.create!(reference_number:, initiator:, owner: registrar_name)
+      log_request(reference_number:, initiator:, owner: registrar_name)
 
       added_count += 1
     end
@@ -24,11 +23,11 @@ class SaveReferenceDataJob < ApplicationJob
     [added_count, skipped_count]
   end
 
-  def log_request(reference_number:, initiator:,  owner:)
+  def log_request(reference_number:, initiator:, owner:)
     Rails.logger.info reference_number
     Rails.logger.info initiator
     Rails.logger.info owner
 
-    Rails.logger.info "++++++++++++++++++"
+    Rails.logger.info '++++++++++++++++++'
   end
 end

--- a/app/views/references/_reference.html.erb
+++ b/app/views/references/_reference.html.erb
@@ -2,5 +2,6 @@
   <td class="px-6 py-1 border-b border-gray-200"><%= reference.reference_number %></td>
   <td class="px-6 py-1 border-b border-gray-200"><%= reference.initiator %></td>
   <td class="px-6 py-1 border-b border-gray-200"><%= reference.owner %></td>
+  <td class="px-6 py-1 border-b border-gray-200"><%= reference.email %></td>
   <td class="px-6 py-1 border-b border-gray-200"><%= reference.created_at %></td>
 <% end %>

--- a/app/views/references/index.html.erb
+++ b/app/views/references/index.html.erb
@@ -25,6 +25,7 @@
               <th class="px-6 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs text-gray-500 uppercase"><%= sort_link_to "Reference number", "reference_number" %></th>
               <th class="px-6 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs text-gray-500 uppercase"><%= sort_link_to "Related", "initiator" %></th>
               <th class="px-6 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs text-gray-500 uppercase"><%= sort_link_to "Owner", "owner" %></th>
+              <th class="px-6 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs text-gray-500 uppercase"><%= sort_link_to "Email", "email" %></th>
               <th class="px-6 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs text-gray-500 uppercase"><%= sort_link_to "Created at", "created_at" %></th>
             </tr>
           </thead>

--- a/db/migrate/20231031100825_add_owner_email_for_references_table.rb
+++ b/db/migrate/20231031100825_add_owner_email_for_references_table.rb
@@ -1,0 +1,5 @@
+class AddOwnerEmailForReferencesTable < ActiveRecord::Migration[7.0]
+  def change
+    add_column :references, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_083243) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_31_100825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_083243) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "app_sessions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_app_sessions_on_user_id"
+  end
+
   create_table "invoices", force: :cascade do |t|
     t.integer "invoice_number", null: false
     t.string "initiator", null: false
@@ -66,6 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_083243) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "owner"
+    t.string "email"
   end
 
   create_table "setting_entries", force: :cascade do |t|
@@ -85,8 +94,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_083243) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "identity_code"
+    t.string "uid", default: "", null: false
+    t.string "provider", default: "", null: false
+  end
+
+  create_table "white_codes", force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "app_sessions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,14 +42,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_31_100825) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "app_sessions", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "token_digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_app_sessions_on_user_id"
-  end
-
   create_table "invoices", force: :cascade do |t|
     t.integer "invoice_number", null: false
     t.string "initiator", null: false
@@ -94,18 +86,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_31_100825) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "identity_code"
-    t.string "uid", default: "", null: false
-    t.string "provider", default: "", null: false
-  end
-
-  create_table "white_codes", force: :cascade do |t|
-    t.string "code", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "app_sessions", "users"
 end

--- a/spec/jobs/payment_lhv_connect_job_spec.rb
+++ b/spec/jobs/payment_lhv_connect_job_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'PaymentLhvConnectJob', type: :job do
       allow_any_instance_of(Net::HTTP).to receive(:post).and_return('200 - ok')
       allow_any_instance_of(PaymentLhvConnectJob).to receive(:open_ssl_keystore).and_return(openssl_struct)
 
-      expect_any_instance_of(PaymentLhvConnectJob).to receive(:send_transactions_to_registry).with(params: [params_for_sending])
+      expect_any_instance_of(PaymentLhvConnectJob).to receive(:send_transactions).with(params: [params_for_sending], payment_reference_number: '2')
       PaymentLhvConnectJob.perform_now
     end
 
@@ -62,7 +62,7 @@ RSpec.describe 'PaymentLhvConnectJob', type: :job do
       openssl_struct = OpenStruct.new(key: 'key', certificate: 'certificate')
       allow_any_instance_of(PaymentLhvConnectJob).to receive(:open_ssl_keystore).and_return(openssl_struct)
 
-      expect_any_instance_of(PaymentLhvConnectJob).not_to receive(:send_transactions_to_registry).with(params: [])
+      expect_any_instance_of(PaymentLhvConnectJob).not_to receive(:send_transactions).with(params: [], payment_reference_number: nil)
       PaymentLhvConnectJob.perform_now
     end
   end
@@ -103,7 +103,7 @@ RSpec.describe 'PaymentLhvConnectJob', type: :job do
         end
       end
 
-      expect_any_instance_of(PaymentLhvConnectJob).to receive(:send_transactions_to_registry).with(params: [params_for_sending])
+      expect_any_instance_of(PaymentLhvConnectJob).to receive(:send_transactions).with(params: [params_for_sending], payment_reference_number: ref)
       PaymentLhvConnectJob.perform_now
     end
   end


### PR DESCRIPTION
close #93 

**What have I done here?**

Actually, there are not that many changes here. It was necessary to modify the old code, which by default sent all transactions only to the registry. However, now there is a need to send transactions to the auction if the reference number points to a user. Therefore, it was necessary to change the mechanism and add a check for whom the reference number belongs and in which service the user is located.

**How to check the work?**
Everything is described here in the section on how to test.

#https://github.com/internetee/auction_center/pull/1180