### PR TITLE
auction invoice status synchronization

### DIFF
--- a/app/controllers/dashboards/invoice_status_controller.rb
+++ b/app/controllers/dashboards/invoice_status_controller.rb
@@ -1,7 +1,7 @@
 class Dashboards::InvoiceStatusController < ParentController
   def update
     @invoice = Invoice.find(params[:id])
-    temporary_unavailable and return unless @invoice.registry?
+    temporary_unavailable and return unless @invoice.allow_to_synchronize?
 
     resp = @invoice.synchronize(status: params[:status])
     if resp.result?

--- a/app/controllers/dashboards/invoice_status_controller.rb
+++ b/app/controllers/dashboards/invoice_status_controller.rb
@@ -4,6 +4,7 @@ class Dashboards::InvoiceStatusController < ParentController
     temporary_unavailable and return unless @invoice.allow_to_synchronize?
 
     resp = @invoice.synchronize(status: params[:status])
+
     if resp.result?
       @invoice.update(status: params[:status])
 

--- a/app/controllers/dashboards/invoice_synchronizes_controller.rb
+++ b/app/controllers/dashboards/invoice_synchronizes_controller.rb
@@ -1,7 +1,7 @@
 class Dashboards::InvoiceSynchronizesController < ParentController
   def update
     @invoice = Invoice.find(params[:id])
-    temporary_unavailable and return unless @invoice.registry?
+    temporary_unavailable and return unless @invoice.allow_to_synchronize?
 
     respond_to do |format|
       format.turbo_stream do

--- a/app/controllers/everypay_controller.rb
+++ b/app/controllers/everypay_controller.rb
@@ -3,16 +3,20 @@ class EverypayController < ParentController
 
   def everypay_data
     response = EverypayResponse.call(params[:payment_reference])
-    Notify.call(response: response)
+    Notify.call(response:)
 
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.replace('response_everypay',
-                                html: "<h2 class='mt-3'>Everypay response result</h2><div class='bg-gray-300 p-4 mt-1 mb-3'><code>#{response}</code></div>".html_safe),
+                               html: html_response(response).html_safe)
         ]
       end
     end
   end
 
+  def html_response(response)
+    "<h2 class='mt-3'>Everypay response result</h2><div class='bg-gray-300 p-4 mt-1 mb-3'>
+     <code>#{response}</code></div>"
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,33 +7,32 @@ class Invoice < ApplicationRecord
   EEID = 'eeid'.freeze
 
   pg_search_scope :search_by_number, against: [:invoice_number],
-  using: {
-    tsearch: {
-      prefix: true
-    }
+                                     using: {
+                                       tsearch: {
+                                         prefix: true
+                                       }
+                                     }
+
+  enum affiliation: { regular: 0, auction_deposit: 1 }
+  enum status: { unpaid: 0, paid: 1, cancelled: 2, failed: 3, refunded: 4, overdue: 5 }
+
+  scope :with_status, lambda { |status|
+    where(status:) if status.present?
   }
 
-  enum affiliation: %i[regular auction_deposit]
-  enum status: %i[unpaid paid cancelled failed refunded]
-
-  scope :with_status, ->(status) {
-    where(status: status) if status.present?
-  }
-
-  scope :with_number, ->(invoice_number) {
+  scope :with_number, lambda { |invoice_number|
     search_by_number(invoice_number) if invoice_number.present?
   }
 
-  scope :with_amount_between, ->(low, high) {
+  scope :with_amount_between, lambda { |low, high|
     where(transaction_amount: low.to_f..high.to_f) if low.present? && high.present?
   }
 
-  def self.search(params={})
-    sort_column = params[:sort].presence_in(%w{ invoice_number status affiliation }) || "id"
-    sort_direction = params[:direction].presence_in(%w{ asc desc }) || "desc"
+  def self.search(params = {})
+    sort_column = params[:sort].presence_in(%w[invoice_number status affiliation]) || 'id'
+    sort_direction = params[:direction].presence_in(%w[asc desc]) || 'desc'
 
-    self
-      .with_number(params[:invoice_number].to_s.downcase)
+    with_number(params[:invoice_number].to_s.downcase)
       .with_status(params[:status])
       .with_amount_between(params[:min_amount], params[:max_amount])
       .order(sort_column => sort_direction)
@@ -59,15 +58,15 @@ class Invoice < ApplicationRecord
 
   def to_h
     {
-      invoice_number: invoice_number,
-      initiator: initiator,
-      payment_reference: payment_reference,
-      transaction_amount: transaction_amount,
-      status: status,
-      in_directo: in_directo,
-      everypay_response: everypay_response,
-      transaction_time: transaction_time,
-      sent_at_omniva: sent_at_omniva
+      invoice_number:,
+      initiator:,
+      payment_reference:,
+      transaction_amount:,
+      status:,
+      in_directo:,
+      everypay_response:,
+      transaction_time:,
+      sent_at_omniva:
     }
   end
 end

--- a/app/models/invoice/synchronization.rb
+++ b/app/models/invoice/synchronization.rb
@@ -2,10 +2,20 @@ module Invoice::Synchronization
   extend ActiveSupport::Concern
 
   def synchronize(status:)
-    InvoiceDataSenderService.call(invoice: self, status: status)
+    return error_structure if restricted_statuses.include?(status) || !allow_to_synchronize?
+
+    InvoiceDataSenderService.call(invoice: self, status:)
   end
 
   def allow_to_synchronize?
     initiator == 'registry' || initiator == 'auction'
+  end
+
+  def restricted_statuses
+    ['overdue']
+  end
+
+  def error_structure
+    Struct.new(:result?, :instance, :errors).new(false, nil, 'You can not change to this status!')
   end
 end

--- a/app/models/invoice/synchronization.rb
+++ b/app/models/invoice/synchronization.rb
@@ -4,4 +4,8 @@ module Invoice::Synchronization
   def synchronize(status:)
     InvoiceDataSenderService.call(invoice: self, status: status)
   end
+
+  def allow_to_synchronize?
+    initiator == 'registry' || initiator == 'auction'
+  end
 end

--- a/app/services/invoice_data_sender_service.rb
+++ b/app/services/invoice_data_sender_service.rb
@@ -31,7 +31,7 @@ class InvoiceDataSenderService
     when 'eeid'
       "#{GlobalVariable::BASE_EEID}/#"
     when 'auction'
-      "#{GlobalVariable::BASE_AUCTION}/#"
+      "#{GlobalVariable::BASE_AUCTION}/eis_billing/invoices"
     else
       false
     end

--- a/app/views/invoices/_invoice.html.erb
+++ b/app/views/invoices/_invoice.html.erb
@@ -4,8 +4,8 @@
     <%= form_with url: dashboards_invoice_status_path(invoice.id), method: :patch, 
                                                                    data: { controller: 'autosave', target: 'autosave.form'} do |f| %>
       <%= f.select :status, options_for_select(Invoice.statuses.invert.values, invoice.status), {},
-          selected: invoice.status, disabled: !invoice.registry?,
-          class: "#{'bg-gray-200' unless invoice.registry? }" ,data: { action: 'autosave#save', target: 'autosave.select' } %>
+          selected: invoice.status, disabled: !invoice.allow_to_synchronize?,
+          class: "#{'bg-gray-200' unless invoice.allow_to_synchronize? }" ,data: { action: 'autosave#save', target: 'autosave.select' } %>
     <% end %>
   </td>
   <td class="px-6 py-1 border-b border-gray-200"><%= invoice.initiator %></td>

--- a/app/views/invoices/_invoice.html.erb
+++ b/app/views/invoices/_invoice.html.erb
@@ -44,6 +44,6 @@
   <td class="px-6 py-1 break-all border-b border-gray-200 text-center">
     <%= button_to dashboards_invoice_synchronize_path(id: invoice.id), method: :put do %>
       <i class="fa-solid fa-arrows-rotate"></i>
-    <% end if invoice.registry? %>
+    <% end if invoice.allow_to_synchronize? %>
   </td>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_21_075925) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_31_100825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_21_075925) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "owner"
+    t.string "email"
   end
 
   create_table "setting_entries", force: :cascade do |t|

--- a/spec/services/invoice_data_sender_service_spec.rb
+++ b/spec/services/invoice_data_sender_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'InvoiceDataSenderService' do
       invoice_sender = InvoiceDataSenderService.new(invoice: invoice, status: 'paid')
       initiator = invoice_sender.send(:to_whom)
 
-      expect(initiator).to eq "#{GlobalVariable::BASE_AUCTION}/#"
+      expect(initiator).to eq "#{GlobalVariable::BASE_AUCTION}/eis_billing/invoices"
     end
 
     it 'should send invoice data to eeid' do


### PR DESCRIPTION
related https://github.com/internetee/auction_center/pull/1183

**What have I done?**
I have implemented the ability to synchronize the status of accounts from the billing side towards the auction. The synchronization works in one direction: from the billing to the auction because the billing system is the source of truth. However, if in the future there will be cases where bidirectional synchronization is also needed, this can certainly be implemented.

**How to test?**
You simply need to change the states in the dropdown next to the accounts and monitor how these changes are applied on the auction side. It is also important to understand that not all states can be applied, and this should be considered during testing. For example, a canceled payment cannot be changed to a paid status, etc.