### PR TITLE
chore: update RuboCop channel to 1.45

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,7 +19,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
-    channel: rubocop-1-12-1
+    channel: rubocop-1-45
     checks:
       Rubocop/Bundler/OrderedGems:
         enabled: false


### PR DESCRIPTION
Updates CodeClimate configuration to use a newer version of RuboCop, moving from version 1.12.1 to 1.45 to ensure compatibility with current Ruby standards and practices.