### PR TITLE
Route LHV bank payments to eeID (issue #210)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ vendor/gems
 Dockerfile.dev.v2
 
 /docs
+.repowise

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ vendor/gems
 .cursorindexingignore
 .specstory/
 Dockerfile.dev.v2
+
+/docs

--- a/app/jobs/payment_lhv_connect_job.rb
+++ b/app/jobs/payment_lhv_connect_job.rb
@@ -120,7 +120,14 @@ class PaymentLhvConnectJob < ApplicationJob
   def send_transactions(params:, payment_reference_number:)
     reference = Reference.find_by(reference_number: payment_reference_number)
 
-    uri = URI.parse(url[reference.initiator.to_sym])
+    target_url = url[reference&.initiator&.to_sym]
+    if target_url.nil?
+      Rails.logger.error "No transaction endpoint for initiator #{reference&.initiator.inspect} " \
+                         "(reference #{payment_reference_number}); skipping"
+      return
+    end
+
+    uri = URI.parse(target_url)
     http = Net::HTTP.new(uri.host, uri.port)
 
     http.use_ssl = true
@@ -130,7 +137,7 @@ class PaymentLhvConnectJob < ApplicationJob
                          OpenSSL::SSL::VERIFY_PEER
                        end
 
-    res = http.post(url[reference.initiator.to_sym], params.to_json, headers)
+    res = http.post(target_url, params.to_json, headers)
 
     Rails.logger.info '>>>>>>'
     Rails.logger.info res.body
@@ -155,7 +162,8 @@ class PaymentLhvConnectJob < ApplicationJob
   def url
     {
       registry: registry_url_transaction,
-      auction: auction_url_transaction
+      auction: auction_url_transaction,
+      eeid: eeid_url_transaction
     }
   end
 
@@ -165,6 +173,10 @@ class PaymentLhvConnectJob < ApplicationJob
 
   def auction_url_transaction
     "#{ENV['base_auction']}/eis_billing/lhv_connect_transactions"
+  end
+
+  def eeid_url_transaction
+    "#{ENV['base_eeid']}/eis_billing/lhv_connect_transactions"
   end
 
   def billing_secret

--- a/app/models/invoice/synchronization.rb
+++ b/app/models/invoice/synchronization.rb
@@ -8,7 +8,7 @@ module Invoice::Synchronization
   end
 
   def allow_to_synchronize?
-    initiator == 'registry' || initiator == 'auction'
+    %w[registry auction eeid].include?(initiator)
   end
 
   def restricted_statuses

--- a/app/services/invoice_data_sender_service.rb
+++ b/app/services/invoice_data_sender_service.rb
@@ -29,7 +29,7 @@ class InvoiceDataSenderService
     when 'registry'
       "#{GlobalVariable::BASE_REGISTRY}/eis_billing/invoices"
     when 'eeid'
-      "#{GlobalVariable::BASE_EEID}/#"
+      "#{GlobalVariable::BASE_EEID}/eis_billing/invoices"
     when 'auction'
       "#{GlobalVariable::BASE_AUCTION}/eis_billing/invoices"
     else

--- a/spec/jobs/payment_lhv_connect_job_spec.rb
+++ b/spec/jobs/payment_lhv_connect_job_spec.rb
@@ -473,4 +473,36 @@ RSpec.describe 'PaymentLhvConnectJob', type: :job do
       expect(result).to eq(ref)
     end
   end
+
+  describe 'routing transactions by initiator' do
+    let(:job) { PaymentLhvConnectJob.new }
+
+    it 'includes the eeid endpoint in the routing table' do
+      expect(job.send(:url)[:eeid]).to eq "#{ENV['base_eeid']}/eis_billing/lhv_connect_transactions"
+    end
+
+    it 'posts eeid transactions to the eeid endpoint without crashing' do
+      Reference.create(reference_number: '778', initiator: 'eeid')
+      allow(job).to receive(:headers).and_return({})
+
+      posted_to = nil
+      allow_any_instance_of(Net::HTTP).to receive(:post) do |_http, path, _body, _headers|
+        posted_to = path
+        OpenStruct.new(body: '200 - ok')
+      end
+
+      params = [OpenStruct.new(amount: '10.0', currency: 'EUR', payment_reference_number: '778')]
+      job.send(:send_transactions, params: params, payment_reference_number: '778')
+
+      expect(posted_to).to eq "#{ENV['base_eeid']}/eis_billing/lhv_connect_transactions"
+    end
+
+    it 'does not crash the batch for an unknown initiator' do
+      Reference.create(reference_number: '779', initiator: 'unknown_app')
+
+      expect do
+        job.send(:send_transactions, params: [], payment_reference_number: '779')
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/services/invoice_data_sender_service_spec.rb
+++ b/spec/services/invoice_data_sender_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'InvoiceDataSenderService' do
       invoice_sender = InvoiceDataSenderService.new(invoice: invoice, status: 'paid')
       initiator = invoice_sender.send(:to_whom)
 
-      expect(initiator).to eq "#{GlobalVariable::BASE_EEID}/#"
+      expect(initiator).to eq "#{GlobalVariable::BASE_EEID}/eis_billing/invoices"
     end
   end
 


### PR DESCRIPTION
Billing polls one shared LHV account for all connected apps, but the transaction routing table and status-sync only handled registry/auction. eeID payments hit url[:eeid]==nil -> URI.parse(nil) and crashed the whole batch; the eeID invoice URL was a broken "/#" stub; and status sync was disabled for eeid.

- payment_lhv_connect_job: add eeid endpoint to the routing table and a guard so an unknown initiator is logged and skipped instead of crashing the batch.
- invoice_data_sender_service: fix eeid URL to /eis_billing/invoices.
- invoice/synchronization: allow eeid to synchronize invoice status.
- specs: fix assertion that locked in the "/#" bug; add eeid/unknown routing tests.